### PR TITLE
Fixed broken scene transition from Level Design -> End Of Game

### DIFF
--- a/Assets/Scenes/Level Design.unity
+++ b/Assets/Scenes/Level Design.unity
@@ -7275,7 +7275,7 @@ PrefabInstance:
     - target: {fileID: 6563598353547664190, guid: a03eb3547a5d9ca438af9365793eb9c4,
         type: 3}
       propertyPath: newSceneName
-      value: ~EndOfGame
+      value: End Of Game
       objectReference: {fileID: 0}
     - target: {fileID: 6563598353547664190, guid: a03eb3547a5d9ca438af9365793eb9c4,
         type: 3}


### PR DESCRIPTION
Was broken due to final scene name change

link below shows what how it's supposed to function
https://i.gyazo.com/64433a6dfdff05209e209d4f2fcc6984.mp4